### PR TITLE
Add qqsub accumulator output variable

### DIFF
--- a/trunk/NDHMS/Data_Rec/rt_include.inc
+++ b/trunk/NDHMS/Data_Rec/rt_include.inc
@@ -66,7 +66,8 @@
   !REAL,    allocatable, DIMENSION(:,:)      :: SOLDEPRT ! QSUBRT, QSUBBDRYRT moved to subsurface io module, SOLDEPRT, ZWATTABLRT move to susurface properties
   REAL,    allocatable, DIMENSION(:,:)      :: SUB_RESID
   REAL,    allocatable, DIMENSION(:,:)      :: q_sfcflx_x,q_sfcflx_y
-  real,    allocatable, dimension(:,:)      :: qqsfc
+  real,    allocatable, dimension(:,:)      :: qqsfc_acc
+  real,    allocatable, dimension(:,:)      :: qqsub_acc
   INTEGER,    allocatable, DIMENSION(:)      :: map_l2g, map_g2l
 
   INTEGER :: nToInd

--- a/trunk/NDHMS/Routing/Noah_distr_routing.F
+++ b/trunk/NDHMS/Routing/Noah_distr_routing.F
@@ -1289,7 +1289,7 @@ subroutine SubsurfaceRouting_drv(did)
             rt_domain(did)%subsurface_static, &
             rt_domain(did)%subsurface_input, &
             rt_domain(did)%subsurface_output, &
-            rt_domain(did)%overland%control%infiltration_excess)
+            rt_domain(did)%qqsub_acc)
     endif
 
 end subroutine SubsurfaceRouting_drv
@@ -1323,7 +1323,7 @@ subroutine OverlandRouting_drv(did)
             rt_domain(did)%jxrt, &
             rt_domain(did)%q_sfcflx_x, &
             rt_domain(did)%q_sfcflx_y, &
-            rt_domain(did)%qqsfc &
+            rt_domain(did)%qqsfc_acc &
             )
         ! ADCHANGE: If overland routing is called, INFXSUBRT is moved to SFCHEADSUBRT, so
         !           zeroing out just in case

--- a/trunk/NDHMS/Routing/Noah_distr_routing_overland.F
+++ b/trunk/NDHMS/Routing/Noah_distr_routing_overland.F
@@ -19,7 +19,7 @@ subroutine OverlandRouting( &
     jxrt, &      ! routing grid y size
     q_sfcflx_x, &! accumulated x flux
     q_sfcflx_y,  &! accumulated y flux
-    qqsfc &
+    qqsfc_acc &
     )
 #ifdef MPP_LAND
     use module_mpp_land, only:  mpp_land_max_int1,  sum_real1, my_id, io_id, numprocs
@@ -32,7 +32,7 @@ subroutine OverlandRouting( &
     integer, INTENT(IN) :: ixrt, jxrt, rt_option
     !REAL, INTENT(out), DIMENSION(IXRT,JXRT)   :: SFCHEADSUBRT  ! moved into overland_data%control
     real, intent(inout) :: q_sfcflx_x,q_sfcflx_y
-    real, intent(out)   :: qqsfc
+    real, intent(inout)   :: qqsfc_acc
 
     ! REMOVED VARIABLES
     !INTEGER, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: LAKE_MSKRT
@@ -128,7 +128,7 @@ subroutine OverlandRouting( &
             rt_option,            &
             q_sfcflx_x,           &
             q_sfcflx_y,           &
-            qqsfc)
+            qqsfc_acc)
     else
         ovrt_data%control%surface_water_head_routing = ovrt_data%control%infiltration_excess
 #ifdef HYDRO_D
@@ -214,7 +214,7 @@ subroutine ov_rtng( &
         rt_option, &
         q_sfcflx_x, &
         q_sfcflx_y, &
-        qqsfc &
+        qqsfc_acc &
         )
 
     !yyww
@@ -249,7 +249,7 @@ subroutine ov_rtng( &
     !REAL, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: LAKE_INFLORT
     !REAL, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: QBDRYRT
     REAL, INTENT(INOUT), DIMENSION(IXRT,JXRT) :: q_sfcflx_x,q_sfcflx_y
-    real, intent(out), dimension(ixrt, jxrt) :: qqsfc
+    real, intent(inout), dimension(ixrt, jxrt) :: qqsfc_acc
     !REAL, INTENT(INOUT)     :: QSTRMVOLTRT,QBDRYTRT,LAKE_INFLOTRT
     !REAL, INTENT(IN), DIMENSION(IXRT,JXRT,8)  :: SO8RT
 
@@ -394,7 +394,7 @@ subroutine ov_rtng( &
                 ovrt_data%control%boundary_flux_total,    &
                 ovrt_data%properties%surface_slope, &
                 ovrt_data%properties%max_surface_slope_index, &
-                q_sfcflx_x, q_sfcflx_y, qqsfc)
+                q_sfcflx_x, q_sfcflx_y, qqsfc_acc)
         else                                                        ! CASC2D
             CALL ROUTE_OVERLAND2(DTRT_TER, &
                 ovrt_data%properties%distance_to_neighbor, &
@@ -407,7 +407,7 @@ subroutine ov_rtng( &
                 IXRT, JXRT, &
                 ovrt_data%control%boundary_flux, &
                 ovrt_data%control%boundary_flux_total,  &
-                q_sfcflx_x,q_sfcflx_y, qqsfc)
+                q_sfcflx_x,q_sfcflx_y, qqsfc_acc)
         end if
 
     END DO          ! END routing time steps
@@ -503,6 +503,7 @@ SUBROUTINE ROUTE_OVERLAND1(dt,                                &
     DH=0.
     DH_tmp=0.
     QBDRY_tmp =0.
+    qqsfc = 0.0
 
     !!! Loop to route water
     do j=2,YY-1
@@ -585,7 +586,7 @@ SUBROUTINE ROUTE_OVERLAND1(dt,                                &
                                 .or. (JYY0 == YY )) then
                             !QBDRY(IXX0,JYY0)=QBDRY(IXX0,JYY0) - qqsfc*1000.
 #endif
-                            QBDRY_tmp(IXX0,JYY0) = QBDRY_tmp(IXX0,JYY0) - qqsfc*1000.
+                            QBDRY_tmp(IXX0,JYY0) = QBDRY_tmp(IXX0,JYY0) - qqsfc*1000.0
                             QBDRYT = QBDRYT - qqsfc
                             DH_tmp(IXX0,JYY0) = DH_tmp(IXX0,JYY0)-tmp_adjust
                         end if
@@ -593,7 +594,8 @@ SUBROUTINE ROUTE_OVERLAND1(dt,                                &
 
                      ! round to nearest 0.1 mm to avoid numerical instabilities with
                      ! different domain decompositions due to various node/MPI layouts
-                    qqsfc_acc(i, j) = qqsfc_acc(i, j) + (aint(qqsfc * 10000) / 10000)
+                    !qqsfc_acc(i, j) = qqsfc_acc(i, j) + (aint(qqsfc * 10000) / 10000)
+                     qqsfc_acc(i, j) = qqsfc_acc(i, j) + (qqsfc * 1000.0) ! mm
 
                     !! End loop to route sfc water
                 end if

--- a/trunk/NDHMS/Routing/Noah_distr_routing_subsurface.F
+++ b/trunk/NDHMS/Routing/Noah_distr_routing_subsurface.F
@@ -1,4 +1,4 @@
-subroutine subsurfaceRouting ( subrt_data, subrt_static, subrt_input, subrt_output)
+subroutine subsurfaceRouting ( subrt_data, subrt_static, subrt_input, subrt_output, qqsub_acc)
 #ifdef MPP_LAND
     use module_mpp_land, only:  mpp_land_com_real, mpp_land_com_integer
     use module_subsurface_data
@@ -28,6 +28,7 @@ subroutine subsurfaceRouting ( subrt_data, subrt_static, subrt_input, subrt_outp
     !REAL, DIMENSION(IXRT,JXRT)   :: ZWATTABLRT
     REAL, DIMENSION(subrt_static%ixrt,subrt_static%jxrt)   :: CWATAVAIL
     INTEGER, DIMENSION(subrt_static%ixrt,subrt_static%jxrt) :: SATLYRCHK
+    real, intent(inout)   :: qqsub_acc
 
     CWATAVAIL = 0.
     CALL FINDZWAT(subrt_static%ixrt,subrt_static%jxrt,subrt_static%NSOIL, &
@@ -55,7 +56,7 @@ subroutine subsurfaceRouting ( subrt_data, subrt_static, subrt_input, subrt_outp
     ! This subroutine returns: ZWATTABLRT, CWATAVAIL and SATLYRCHK
 
 
-    CALL SUBSFC_RTNG( subrt_data, subrt_static, subrt_input, subrt_output, CWATAVAIL, SATLYRCHK)
+    CALL SUBSFC_RTNG( subrt_data, subrt_static, subrt_input, subrt_output, CWATAVAIL, SATLYRCHK, qqsub_acc)
 
 #ifdef HYDRO_D
     print *, "SUBROUTE routing called and returned..."
@@ -67,7 +68,8 @@ end subroutine subsurfaceRouting
 !DJG   SUBROUTINE SUBSFC_RTNG
 !DJG ------------------------------------------------
 
-SUBROUTINE SUBSFC_RTNG(subrt_data, subrt_static, subrt_input, subrt_output, CWATAVAIL, SATLYRCHK)
+SUBROUTINE SUBSFC_RTNG(subrt_data, subrt_static, subrt_input, subrt_output, &
+                       CWATAVAIL, SATLYRCHK, qqsub_acc)
 
     !       use module_mpp_land, only: write_restart_rt_3, write_restart_rt_2, &
         !            my_id
@@ -100,7 +102,7 @@ SUBROUTINE SUBSFC_RTNG(subrt_data, subrt_static, subrt_input, subrt_output, CWAT
     !REAL, INTENT(IN), DIMENSION(IXRT,JXRT)   :: ZWATTABLRT
     REAL, INTENT(IN), DIMENSION(subrt_static%ixrt,subrt_static%jxrt)   :: CWATAVAIL
     INTEGER, INTENT(IN), DIMENSION(subrt_static%ixrt,subrt_static%jxrt) :: SATLYRCHK
-
+    real, intent(inout), dimension(subrt_static%ixrt,subrt_static%jxrt)   :: qqsub_acc
 
     !REAL, INTENT(OUT), DIMENSION(IXRT,JXRT)   :: QSUBRT
     !REAL, INTENT(OUT), DIMENSION(IXRT,JXRT)   :: QSUBBDRYRT
@@ -162,6 +164,8 @@ SUBROUTINE SUBSFC_RTNG(subrt_data, subrt_static, subrt_input, subrt_output, CWAT
     !DJG    - SUBSURFACE ROUITNG ONLY PERFORMED ON SATURATED LAYERS
     !DJG -----------------------------------------------------------------
 
+SUBDT = subrt_static%dt                !-- initialize the routing timestep to DT
+
 #ifdef HYDRO_D
     ! ADCHANGE: START Initial water balance variables
     ! ALL VARS in MM
@@ -204,8 +208,6 @@ SUBROUTINE SUBSFC_RTNG(subrt_data, subrt_static, subrt_input, subrt_output, CWAT
 
     !DJG Set up mass balance checks...
     !         CWATAVAIL = 0.            !-- initialize subsurface watavail
-    SUBDT = subrt_static%dt                !-- initialize the routing timestep to DT
-
 
     !!!! Find saturated layer depth...
     ! Loop through domain to determine sat. layers and assign wat tbl depth...
@@ -247,7 +249,7 @@ SUBROUTINE SUBSFC_RTNG(subrt_data, subrt_static, subrt_input, subrt_output, CWAT
                            subrt_data%properties%max_surface_slope_index, &
                            CWATAVAIL, SUBDT, &
                            subrt_data%state%qsubbdryrt, subrt_data%state%qsubbdrytrt, &
-                           subrt_data%state%qsubrt)
+                           subrt_data%state%qsubrt, qqsub_acc)
     !     else
     !        CALL ROUTE_SUBSURFACE2(subrt_data%properties%distance_to_neighbor,subrt_data%properties%zwattablrt, &
         !               subrt_data%state%qsubrt, subrt_data%properties%surface_slope_x, subrt_data%properties%surface_slope_y, &
@@ -562,7 +564,7 @@ END SUBROUTINE FINDZWAT
 !===================================================================================================
 SUBROUTINE ROUTE_SUBSURFACE1(dist, z, latksat, soldep, &
                              XX, YY, SO8RT, SO8RT_D, &
-                             CWATAVAIL, SUBDT, QSUBDRY, QSUBDRYT, qsub)
+                             CWATAVAIL, SUBDT, QSUBDRY, QSUBDRYT, qsub, qqsub_acc)
 #ifdef MPP_LAND
    use module_mpp_land, only: left_id, down_id, right_id, up_id, &
                               mpp_land_com_real8, my_id, mpp_land_com_real
@@ -587,6 +589,7 @@ SUBROUTINE ROUTE_SUBSURFACE1(dist, z, latksat, soldep, &
    real, intent(inout)                     :: QSUBDRYT
                                               ! total subsurface flow outside of domain (m3/s)
    real, intent(out), dimension(XX,YY)     :: qsub ! subsurface flow outside of cell (m3/s)
+   real, intent(inout), dimension(XX,YY)     :: qqsub_acc ! accumulated subsurface flow outside of cell (mm)
 
    ! Local variables
    integer :: i, j ! indices for local loops
@@ -703,6 +706,9 @@ SUBROUTINE ROUTE_SUBSURFACE1(dist, z, latksat, soldep, &
                   QSUBDRYT = QSUBDRYT + qqsub
                endif
 
+               ! Update accumulator term, converted to positive depth in mm
+               qqsub_acc(i,j) = qqsub_acc(i,j) + ( (0.0-qqsub) / dist(i,j,9) * SUBDT * 1000.0 )
+
             endif  ! end if for flux calc
 
          endif   ! end if for gridcell check
@@ -725,6 +731,7 @@ SUBROUTINE ROUTE_SUBSURFACE1(dist, z, latksat, soldep, &
 #ifdef MPP_LAND
    call MPP_LAND_COM_REAL(qsub,XX,YY,99)
    call MPP_LAND_COM_REAL(QSUBDRY,XX,YY,99)
+   call MPP_LAND_COM_REAL(qqsub_acc,XX,YY,99)
 #endif
 
    return

--- a/trunk/NDHMS/Routing/Reservoirs/RFC_Forecasts/module_rfc_forecasts.F
+++ b/trunk/NDHMS/Routing/Reservoirs/RFC_Forecasts/module_rfc_forecasts.F
@@ -226,7 +226,7 @@ contains
 
                 !! peak flow on MS river *2
                 !! http://nwis.waterdata.usgs.gov/nwis/peak?site_no=07374000&agency_cd=USGS&format=html
-                !! baton rouge 1945: 1,473,000cfs=41,711cfs, multiply it roughly by 2
+                !! baton rouge 1945: 1,473,000cfs=41,711cms, multiply it roughly by 2
                 else if (maxval(this%state%discharges) .ge. 90000.0) then
                     this%state%forecast_found = .false.
 

--- a/trunk/NDHMS/Routing/Reservoirs/module_reservoir_read_timeslice_data.F
+++ b/trunk/NDHMS/Routing/Reservoirs/module_reservoir_read_timeslice_data.F
@@ -306,7 +306,7 @@ contains
 
         !! peak flow on MS river *2
         !! http://nwis.waterdata.usgs.gov/nwis/peak?site_no=07374000&agency_cd=USGS&format=html
-        !! baton rouge 1945: 1,473,000cfs=41,711cfs, multiply it roughly by 2
+        !! baton rouge 1945: 1,473,000cfs=41,711cms, multiply it roughly by 2
         where(this%gage_discharge .ge. 90000.0) this%gage_quality=0
 
         ! Loop through reservoir gage array to look for gages that still have discharges set to -1.0.

--- a/trunk/NDHMS/Routing/module_NWM_io.F
+++ b/trunk/NDHMS/Routing/module_NWM_io.F
@@ -1804,25 +1804,25 @@ subroutine output_rt_NWM(domainId,iGrid)
 
    if(nlst(domainId)%io_config_outputs .eq. 0) then
       ! All
-      fileMeta%outFlag(:) = [1,1,1,1,1,1]
+      fileMeta%outFlag(:) = [1,1,1,1,1,1,1]
    else if(nlst(domainId)%io_config_outputs .eq. 1) then
       ! Analysis and Assimilation
-      fileMeta%outFlag(:) = [1,1,0,0,0,0]
+      fileMeta%outFlag(:) = [1,1,0,0,0,0,0]
    else if(nlst(domainId)%io_config_outputs .eq. 2) then
       ! Short Range
-      fileMeta%outFlag(:) = [1,1,0,0,0,0]
+      fileMeta%outFlag(:) = [1,1,0,0,0,0,0]
    else if(nlst(domainId)%io_config_outputs .eq. 3) then
       ! Medium Range
-      fileMeta%outFlag(:) = [1,1,0,0,0,0]
+      fileMeta%outFlag(:) = [1,1,0,0,0,0,0]
    else if(nlst(domainId)%io_config_outputs .eq. 4) then
       ! Long Range
-      fileMeta%outFlag(:) = [1,1,0,0,0,0]
+      fileMeta%outFlag(:) = [1,1,0,0,0,0,0]
    else if(nlst(domainId)%io_config_outputs .eq. 5) then
       ! Retrospective
-      fileMeta%outFlag(:) = [1,1,0,0,0,0]
+      fileMeta%outFlag(:) = [1,1,0,0,0,0,0]
    else if(nlst(domainId)%io_config_outputs .eq. 6) then
       ! Diagnostics
-      fileMeta%outFlag(:) = [1,1,0,0,0,0]
+      fileMeta%outFlag(:) = [1,1,0,0,0,0,0]
    else
       call nwmCheck(diagFlag,1,'ERROR: Invalid IOC flag provided by namelist file.')
    endif
@@ -2185,7 +2185,9 @@ subroutine output_rt_NWM(domainId,iGrid)
                   else if(iTmp2 .eq. 5) then
                      varRealTmp = rt_domain(domainId)%subsurface%grid_transform%smcrt(iTmp,jTmp,zTmp)
                   else if(iTmp2 .eq. 6) then
-                     varRealTmp = rt_domain(domainId)%qqsfc(iTmp,jTmp)
+                     varRealTmp = rt_domain(domainId)%qqsfc_acc(iTmp,jTmp)
+                  else if(iTmp2 .eq. 7) then
+                     varRealTmp = rt_domain(domainId)%qqsub_acc(iTmp,jTmp)
                   endif
 
                   ! Run a quick gross check on values to ensure they aren't outside our
@@ -2269,8 +2271,9 @@ subroutine output_rt_NWM(domainId,iGrid)
       call nwmCheck(diagFlag,iret,'ERROR: Unable to close RT_DOMAIN file.')
    endif
 
-   ! clear the qqsfc accumulator after output
-   rt_domain(domainId)%qqsfc(:,:) = 0.0
+   ! clear the qq accumulators after output
+   rt_domain(domainId)%qqsfc_acc(:,:) = 0.0
+   rt_domain(domainId)%qqsub_acc(:,:) = 0.0
 
 end subroutine output_rt_NWM
 

--- a/trunk/NDHMS/Routing/module_NWM_io_dict.F
+++ b/trunk/NDHMS/Routing/module_NWM_io_dict.F
@@ -20,7 +20,7 @@ implicit none
 ! Declare parameter values for module.
 integer, parameter :: numChVars = 10
 integer, parameter :: numLdasVars = 98
-integer, parameter :: numRtDomainVars = 6
+integer, parameter :: numRtDomainVars = 7
 integer, parameter :: numLakeVars = 2
 integer, parameter :: numChGrdVars = 1
 integer, parameter :: numLsmVars = 14
@@ -1630,21 +1630,22 @@ subroutine initRtDomainDict(rtDomainDict,procId,diagFlag)
    endif
 
    rtDomainDict%varNames(:) = [character(len=64) :: "zwattablrt", "sfcheadsubrt", "QSTRMVOLRT", &
-                               "QBDRYRT", "SOIL_M", "qqsfc" ]   !, &
+                               "QBDRYRT", "SOIL_M", "qqsfc_acc", "qqsub_acc" ]   !, &
                               !"q_sfcflx_x", "q_sfcflx_y"]
    rtDomainDict%longName(:) = [character(len=64) :: "water table depth","surface head",&
                                "channel inflow",&
                                "accumulated value of the boundary flux, + into domain - out of domain",&
-                               "volumetric soil moisture", "accumulated depth of overland water leaving cell"]
-   rtDomainDict%units(:) = [character(len=64) :: "m","mm","mm","mm","m3 m-3", "m"]
-   rtDomainDict%scaleFactor(:) = [0.1,1.0,1.0,1.0,0.01,0.1]
-   rtDomainDict%addOffset(:) = [0.0,0.0,0.0,0.0,0.0,0.0]
-   rtDomainDict%outFlag(:) = [0,0,0,0,0,0]
-   rtDomainDict%timeZeroFlag(:) = [1,1,1,1,1,1]
-   rtDomainDict%missingReal(:) = [-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0]
-   rtDomainDict%fillReal(:) = [-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0]
-   rtDomainDict%validMinDbl(:) = [0.0d0, 0.0d0, 0.0d0, -1000000.0d0, 0.0d0, 0.0d0]
-   rtDomainDict%validMaxDbl(:) = [100.0d0, 1000000.0d0, 1000000.0d0, 1000000.0d0, 100.0d0, 100d0]
+                               "volumetric soil moisture", "accumulated depth of overland water leaving cell", &
+                               "accumulated depth of subsurface water leaving cell"]
+   rtDomainDict%units(:) = [character(len=64) :: "m","mm","mm","mm","m3 m-3", "mm", "mm"]
+   rtDomainDict%scaleFactor(:) = [0.1,1.0,1.0,1.0,0.01,0.001,0.001]
+   rtDomainDict%addOffset(:) = [0.0,0.0,0.0,0.0,0.0,0.0,0.0]
+   rtDomainDict%outFlag(:) = [0,0,0,0,0,0,0]
+   rtDomainDict%timeZeroFlag(:) = [1,1,1,1,1,1,1]
+   rtDomainDict%missingReal(:) = [-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0]
+   rtDomainDict%fillReal(:) = [-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0,-9999.0]
+   rtDomainDict%validMinDbl(:) = [0.0d0, 0.0d0, 0.0d0, -1000000.0d0, 0.0d0, 0.0d0, -1000000.0d0]
+   rtDomainDict%validMaxDbl(:) = [100.0d0, 1000000.0d0, 1000000.0d0, 1000000.0d0, 100.0d0, 1000000d0, 1000000.0d0]
 
    ! Loop through and calculate missing/fill/min/max values that will be placed
    ! into the NetCDF attributes after scale_factor/add_offset are applied.

--- a/trunk/NDHMS/Routing/module_RT.F
+++ b/trunk/NDHMS/Routing/module_RT.F
@@ -193,8 +193,10 @@ CONTAINS
      rt_domain(did)%q_sfcflx_x  = 0.0
      allocate( rt_domain(did)%q_sfcflx_y  (IXRT,JXRT) )
      rt_domain(did)%q_sfcflx_y  = 0.0
-     allocate( rt_domain(did)%qqsfc  (IXRT,JXRT) )
-     rt_domain(did)%qqsfc  = 0.0
+     allocate( rt_domain(did)%qqsfc_acc  (IXRT,JXRT) )
+     rt_domain(did)%qqsfc_acc  = 0.0
+     allocate( rt_domain(did)%qqsub_acc  (IXRT,JXRT) )
+     rt_domain(did)%qqsub_acc  = 0.0
      !allocate( rt_domain(did)%subsurface%grid_transform%smcmaxrt   	(IXRT,JXRT,NSOIL) )
      !rt_domain(did)%subsurface%grid_transform%smcmaxrt   	= 0.0
      !allocate( rt_domain(did)%subsurface%grid_transform%smcwltrt   	(IXRT,JXRT,NSOIL) )

--- a/trunk/NDHMS/nudging/module_nudging_io.F
+++ b/trunk/NDHMS/nudging/module_nudging_io.F
@@ -195,7 +195,7 @@ if (sanityQcDischarge) then
    where(gageDischarge .le. 0.000) gageQC=0
    !! peak flow on MS river *2
    !! http://nwis.waterdata.usgs.gov/nwis/peak?site_no=07374000&agency_cd=USGS&format=html
-   !! baton rouge 1945: 1,473,000cfs=41,711cfs, multiply it roughly by 2
+   !! baton rouge 1945: 1,473,000cfs=41,711cms, multiply it roughly by 2
    where(gageDischarge .ge. 90000.0) gageQC=0
    if(any(gageQc .eq. 0)) then
       write(6,*) 'Ndg: some gageQC set to zero'


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: subsurface routing, I/O

SOURCE: Aubrey, NCAR 

DESCRIPTION OF CHANGES: Added subsurface outflow (not net) accumulated flux from cell as a routing grid output variable.

ISSUE: N/A

TESTS CONDUCTED: Confirmed no answer changes, just new output var.

### Checklist
Merging the PR depends on following checklist being completed. Add `X` between each of the square 
brackets if they are completed in the PR itself. If a bullet is not relevant to you, please comment 
on why below the bullet.

 - [ ] Closes issue #xxxx (An issue must exist or be created to be closed. The issue describes and documents the problem and general solution, the PR describes the technical details of the solution.) 
 - [ ] Tests added (unit tests and/or regression/integration tests)
 - [ ] Backwards compatible
 - [ ] Requires new files? If so, how to generate them.
 - [ ] Fully documented
 - [ ] Short description in the Development section of `NEWS.md`
